### PR TITLE
update amqp and hw-event-proxy ports

### DIFF
--- a/examples/manifests/consumer.yaml
+++ b/examples/manifests/consumer.yaml
@@ -31,7 +31,7 @@ spec:
           args:
             - "--local-api-addr=127.0.0.1:9089"
             - "--api-path=/api/cloudNotifications/v1/"
-            - "--api-addr=127.0.0.1:8080"
+            - "--api-addr=127.0.0.1:8089"
           env:
             - name: NODE_NAME
               valueFrom:
@@ -47,7 +47,7 @@ spec:
             - "--metrics-addr=127.0.0.1:9091"
             - "--store-path=/store"
             - "--transport-host=amqp://router.$(AMQP_NAMESPACE).svc.cluster.local"
-            - "--api-port=8080"
+            - "--api-port=8089"
           env:
             - name: AMQP_NAMESPACE
               value: "amqp-interconnect"

--- a/examples/manifests/hw-event-proxy.yaml
+++ b/examples/manifests/hw-event-proxy.yaml
@@ -22,7 +22,7 @@ spec:
         - name: hw-event-proxy
           image: quay.io/redhat_emp1/hw-event-proxy:latest
           args:
-            - "--api-port=8080"
+            - "--api-port=8089"
           ports:
             - name: hw-event-port
               containerPort: 9087
@@ -36,6 +36,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: HW_EVENT_PROXY_SERVICE_SERVICE_PORT
+              value: "9087"
             - name: MSG_PARSER_PORT
               value: "9097"
             - name: MSG_PARSER_TIMEOUT

--- a/hw-event-proxy/cmd/main.go
+++ b/hw-event-proxy/cmd/main.go
@@ -64,7 +64,7 @@ var (
 )
 
 func main() {
-	flag.IntVar(&apiPort, "api-port", 8080, "The address the rest api endpoint binds to.")
+	flag.IntVar(&apiPort, "api-port", 8089, "The address the rest api endpoint binds to.")
 	flag.Parse()
 	util.InitLogger()
 


### PR DESCRIPTION
- Update hw-event-proxy to use the same amqp port (8089) as the sidecar.
- Expose hw-event-proxy webhook port with env variable
- 
Signed-off-by: Jack Ding <jacding@redhat.com>