### PR TITLE
update build scripts

### DIFF
--- a/scripts/build-go.sh
+++ b/scripts/build-go.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
 
 set -eu
+# Export GO111MODULE=on to enable project to be built from within GOPATH/src
+export GO111MODULE=on
+export CGO_ENABLED=1
+export GOFLAGS=-mod=vendor
+export COMMON_GO_ARGS=-race
+export GOOS=linux
 make -C ./hw-event-proxy build-only

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -8,4 +8,4 @@ if [ -z ${VERSION+a} ]; then
 fi
 NAME=${REPO}:${VERSION}
 
-${BUILDCMD} -f Dockerfile -t "${NAME}" $(dirname $0)/..
+${BUILDCMD} -f Dockerfile.dev -t "${NAME}" $(dirname $0)/..


### PR DESCRIPTION
Fix the following issue in quay.io:

RUN/scripts/build-go.sh
vendor/google.golang.org/grpc/internal/envconfig/envconfig.go:26:2:
cannot find package "." in: /go/src/github.com/redhat-cne/hw-event-proxy
/hw-event-proxy/vendor/google.golang.org/grpc/internal/xds/env

Signed-off-by: Jack Ding <jacding@redhat.com>