### PR TITLE
Fix build dependencies in quay.io

### DIFF
--- a/scripts/build-go.sh
+++ b/scripts/build-go.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 
 set -eu
-# Export GO111MODULE=on to enable project to be built from within GOPATH/src
-export GO111MODULE=on
-export CGO_ENABLED=1
-export GOFLAGS=-mod=vendor
-export COMMON_GO_ARGS=-race
-export GOOS=linux
+export GOFLAGS=
+go mod init tmp
 make -C ./hw-event-proxy build-only


### PR DESCRIPTION
Fix the following issue in quay.io:

RUN/scripts/build-go.sh
vendor/google.golang.org/grpc/internal/envconfig/envconfig.go:26:2:
cannot find package "." in: /go/src/github.com/redhat-cne/hw-event-proxy
/hw-event-proxy/vendor/google.golang.org/grpc/internal/xds/env

Signed-off-by: Jack Ding <jacding@redhat.com>