### PR TITLE
Fix build error for google.golang.org/grpc

### DIFF
--- a/scripts/build-go.sh
+++ b/scripts/build-go.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 
 set -eu
+make -C ./hw-event-proxy deps-update
 make -C ./hw-event-proxy build-only


### PR DESCRIPTION
RUN/scripts/build-go.sh
vendor/google.golang.org/grpc/internal/envconfig/envconfig.go:26:2:
cannot find package "." in: /go/src/github.com/redhat-cne/hw-event-proxy
/hw-event-proxy/vendor/google.golang.org/grpc/internal/xds/env

Signed-off-by: Jack Ding <jacding@redhat.com>