### PR TITLE
Add source in event

### DIFF
--- a/hw-event-proxy/cmd/main.go
+++ b/hw-event-proxy/cmd/main.go
@@ -187,7 +187,7 @@ func handleHwEvent(ctx *fasthttp.RequestCtx) {
 
 	data := v1event.CloudNativeData()
 	value := event.DataValue{
-		Resource:  resourceAddress,
+		Resource:  string(redfish.Systems),
 		DataType:  event.NOTIFICATION,
 		ValueType: event.REDFISH_EVENT,
 		Value:     redfishEvent,
@@ -233,6 +233,7 @@ func createHwEvent() event.Event {
 	e := v1event.CloudNativeEvent()
 	e.ID = pub.ID
 	e.Type = string(redfish.Alert)
+	e.Source = resourceAddress
 	e.SetTime(types.Timestamp{Time: time.Now().UTC()}.Time)
 	e.SetDataContentType(event.ApplicationJSON)
 	return e

--- a/hw-event-proxy/go.mod
+++ b/hw-event-proxy/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/json-iterator/go v1.1.12
-	github.com/redhat-cne/sdk-go v0.1.1-0.20211206194140-5b52c616af2b
+	github.com/redhat-cne/sdk-go v0.1.1-0.20220105170230-b17827c91503
 	github.com/sirupsen/logrus v1.8.1
 	github.com/valyala/fasthttp v1.31.0
 	golang.org/x/net v0.0.0-20210903162142-ad29c8ab022f

--- a/hw-event-proxy/go.sum
+++ b/hw-event-proxy/go.sum
@@ -139,8 +139,8 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
-github.com/redhat-cne/sdk-go v0.1.1-0.20211206194140-5b52c616af2b h1:Z7Y2QrpCyLiAWTGz0yyJtxOu3T7f9GCXAD/sYHdpcVk=
-github.com/redhat-cne/sdk-go v0.1.1-0.20211206194140-5b52c616af2b/go.mod h1:1FXE/O2PhDnazeCidsAIJJ5lLaaWHBXNP5HxaJ1hf0U=
+github.com/redhat-cne/sdk-go v0.1.1-0.20220105170230-b17827c91503 h1:gfwZqJ0xiWF6eDrtQuYhzRblG7LBHYUbskUl0A+IANs=
+github.com/redhat-cne/sdk-go v0.1.1-0.20220105170230-b17827c91503/go.mod h1:1FXE/O2PhDnazeCidsAIJJ5lLaaWHBXNP5HxaJ1hf0U=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/event/event.go
+++ b/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/event/event.go
@@ -28,30 +28,20 @@ import (
 //{
 //	"id": "5ce55d17-9234-4fee-a589-d0f10cb32b8e",
 //	"type": "event.sync.sync-status.synchronization-state-change",
+//	"source": "/cluster/node/example.com/ptp/clock_realtime",
 //	"time": "2021-02-05T17:31:00Z",
 //	"data": {
 //		"version": "v1.0",
 //		"values": [{
-//			"resource": "/cluster/node/ptp",
+//			"resource": "/sync/sync-status/sync-state",
 //			"dataType": "notification",
 //			"valueType": "enumeration",
 //			"value": "ACQUIRING-SYNC"
 //			}, {
-//			"resource": "/cluster/node/clock",
+//			"resource": "/sync/sync-status/sync-state",
 //			"dataType": "metric",
 //			"valueType": "decimal64.3",
 //			"value": 100.3
-//			}, {
-//			"resource": "/cluster/node/temp",
-//			"dataType": "notification",
-//			"valueType": "redfish-event",
-//			"value": {
-//			"@odata.context": "/redfish/v1/$metadata#Event.Event",
-//			"@odata.type": "#Event.v1_3_0.Event",
-//			"Context": "any string is valid",
-//			"Events": [{"EventId": "2162", "MemberId": "615703", "MessageId": "TMP0100"}],
-//			"Id": "5e004f5a-e3d1-11eb-ae9c-3448edf18a38",
-//			"Name": "Event Array"
 //			}]
 //		}
 //}
@@ -63,6 +53,9 @@ type Event struct {
 	// Type - The type of the occurrence which has happened.
 	// +required
 	Type string `json:"type" example:"event.sync.sync-status.synchronization-state-change"`
+	// Source - The source of the occurrence which has happened.
+	// +required
+	Source string `json:"source" example:"/cluster/node/example.com/ptp/clock_realtime"`
 	// DataContentType - the Data content type
 	// +required
 	DataContentType *string `json:"dataContentType" example:"application/json"`

--- a/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/event/event_ce.go
+++ b/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/event/event_ce.go
@@ -50,6 +50,7 @@ func (e *Event) GetCloudNativeEvents(ce *cloudevent.Event) (err error) {
 	e.SetDataContentType(ApplicationJSON)
 	e.SetTime(ce.Time())
 	e.SetType(ce.Type())
+	e.SetSource(ce.Source())
 	e.SetData(data)
 	return
 }

--- a/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/event/event_data.go
+++ b/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/event/event_data.go
@@ -46,17 +46,17 @@ const (
 //{
 //	"version": "v1.0",
 //	"values": [{
-//		"resource": "/cluster/node/ptp",
+//		"resource": "/sync/sync-status/sync-state",
 //		"dataType": "notification",
 //		"valueType": "enumeration",
 //		"value": "ACQUIRING-SYNC"
 //		}, {
-//		"resource": "/cluster/node/clock",
+//		"resource": "/sync/sync-status/sync-state",
 //		"dataType": "metric",
 //		"valueType": "decimal64.3",
 //		"value": 100.3
 //		}, {
-//		"resource": "/cluster/node/temp",
+//		"resource": "/redfish/v1/Systems",
 //		"dataType": "notification",
 //		"valueType": "redfish-event",
 //		"value": {

--- a/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/event/event_marshal.go
+++ b/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/event/event_marshal.go
@@ -39,6 +39,10 @@ func WriteJSON(in *Event, writer io.Writer) error {
 
 			stream.WriteObjectField("type")
 			stream.WriteString(in.GetType())
+			stream.WriteMore()
+
+			stream.WriteObjectField("source")
+			stream.WriteString(in.GetSource())
 
 			if in.GetDataContentType() != "" {
 				stream.WriteMore()

--- a/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/event/event_reader.go
+++ b/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/event/event_reader.go
@@ -25,6 +25,11 @@ func (e *Event) GetType() string {
 	return e.Type
 }
 
+// GetSource implements Reader.Source
+func (e *Event) GetSource() string {
+	return e.Source
+}
+
 // GetID implements Reader.ID
 func (e *Event) GetID() string {
 	return e.ID

--- a/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/event/event_unmarshal.go
+++ b/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/event/event_unmarshal.go
@@ -85,11 +85,12 @@ func readDataJSONFromIterator(out *Data, iterator *jsoniter.Iterator) error {
 func readJSONFromIterator(out *Event, iterator *jsoniter.Iterator) error {
 	var (
 		// Universally parseable fields.
-		id   string
-		typ  string
-		time *types.Timestamp
-		data *Data
-		err  error
+		id     string
+		typ    string
+		source string
+		time   *types.Timestamp
+		data   *Data
+		err    error
 
 		// These fields require knowledge about the specversion to be parsed.
 		//schemaurl jsoniter.Any
@@ -107,6 +108,8 @@ func readJSONFromIterator(out *Event, iterator *jsoniter.Iterator) error {
 			id = iterator.ReadString()
 		case "type":
 			typ = iterator.ReadString()
+		case "source":
+			source = iterator.ReadString()
 		case "time":
 			time = readTimestamp(iterator)
 		case "data":
@@ -130,6 +133,7 @@ func readJSONFromIterator(out *Event, iterator *jsoniter.Iterator) error {
 	out.Time = time
 	out.ID = id
 	out.Type = typ
+	out.Source = source
 	if data != nil {
 		out.SetData(*data)
 	}

--- a/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/event/event_writer.go
+++ b/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/event/event_writer.go
@@ -29,6 +29,11 @@ func (e *Event) SetType(t string) {
 	e.Type = t
 }
 
+// SetSource implements Writer.SetSource
+func (e *Event) SetSource(s string) {
+	e.Source = s
+}
+
 // SetID implements Writer.SetID
 func (e *Event) SetID(id string) {
 	e.ID = id

--- a/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/event/redfish/resource.go
+++ b/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/event/redfish/resource.go
@@ -1,0 +1,23 @@
+// Copyright 2021 The Cloud Native Events Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redfish
+
+// EventResource ...
+type EventResource string
+
+const (
+	// Systems is odata.id of the generic origin of redfish events
+	Systems EventResource = "/redfish/v1/Systems"
+)

--- a/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/v1/event/event.go
+++ b/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/v1/event/event.go
@@ -110,6 +110,7 @@ func GetCloudNativeEvents(ce cloudevents.Event) (e event.Event, err error) {
 	e.SetDataContentType(event.ApplicationJSON)
 	e.SetTime(ce.Time())
 	e.SetType(ce.Type())
+	e.SetSource(ce.Source())
 	e.SetData(data)
 	return
 }

--- a/hw-event-proxy/vendor/modules.txt
+++ b/hw-event-proxy/vendor/modules.txt
@@ -41,7 +41,7 @@ github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.2
 ## explicit; go 1.12
 github.com/modern-go/reflect2
-# github.com/redhat-cne/sdk-go v0.1.1-0.20211206194140-5b52c616af2b
+# github.com/redhat-cne/sdk-go v0.1.1-0.20220105170230-b17827c91503
 ## explicit; go 1.17
 github.com/redhat-cne/sdk-go/pkg/channel
 github.com/redhat-cne/sdk-go/pkg/event


### PR DESCRIPTION
Add source as a required attribute in event.
Update the resource under event.data.values to be resource
type instead of the source.

Signed-off-by: Jack Ding <jacding@redhat.com>