### PR TITLE
Fix HTTPS edge route

### DIFF
--- a/manifests/base/route.yaml
+++ b/manifests/base/route.yaml
@@ -2,6 +2,8 @@ apiVersion: route.openshift.io/v1
 
 kind: Route
 metadata:
+  annotations:
+    haproxy.router.openshift.io/disable_cookies: true
   name: hw-event-proxy
   namespace: cloud-native-events
 spec:
@@ -10,3 +12,5 @@ spec:
     name: hw-event-proxy-service
   tls:
     termination: edge
+  port:
+    targetPort: 9087

--- a/manifests/base/service.yaml
+++ b/manifests/base/service.yaml
@@ -13,9 +13,6 @@ spec:
     - name: hw-event
       port: 9087
       targetPort: 9087
-    - name: https
-      port: 8443
-      targetPort: https
   selector:
     app: hw-event-proxy
   type: ClusterIP


### PR DESCRIPTION
Issue:
Every other http POST request failed with 404 and
error message "Client sent an HTTP request to an HTTPS server".

Root Cause:
There are 2 ports present in hw-event-proxy-service:
HTTP port 9087 and HTTPS port 8443. When a POST request arrives,
HAProxy does round robin between the two endpoints. The one
landed on port 8443 caused the error message.

Solution:
Removed the extra https port in hw-event-proxy-service.
Add targetPort:9087 in the edge route to prevent issues from
happening again in the future if more ports were added.
Add annotation to disable cookie as cookies are not really used in the Webhook.

Signed-off-by: Jack Ding <jacding@redhat.com>