### PR TITLE
Add timeout to CI golangci-lint

### DIFF
--- a/.github/workflows/hw-event-proxy.yaml
+++ b/.github/workflows/hw-event-proxy.yaml
@@ -23,7 +23,8 @@ jobs:
           skip-pkg-cache: true
           skip-build-cache: true
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.42.1
+          version: v1.42
+          args: --timeout 3m0s
           working-directory: ./hw-event-proxy
   unit-tests:
     name: Unit Tests


### PR DESCRIPTION
CI Linting job fails intermittently due to timeout.
Increase the timeout to 3m. The timeout issue and suggested
solution can be found at
golangci/golangci-lint-action#297

Signed-off-by: Jack Ding <jacding@redhat.com>