### PR TITLE
Update resource address and consumer image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ VERSION ?=latest
 # Image name
 PROXY_IMG_NAME ?= quay.io/openshift/origin-baremetal-hardware-event-proxy
 SIDECAR_IMG_NAME ?= quay.io/openshift/origin-cloud-event-proxy
-CONSUMER_IMG_NAME ?= quay.io/redhat-cne/cloud-native-event-consumer
+CONSUMER_IMG_NAME ?= quay.io/redhat-cne/cloud-event-consumer
 
 PROXY_IMG ?= ${PROXY_IMG_NAME}:${VERSION}
 SIDECAR_IMG ?= ${SIDECAR_IMG_NAME}:${VERSION}

--- a/docs/development.md
+++ b/docs/development.md
@@ -74,7 +74,7 @@ podman push localhost/hw-event-proxy:${TAG} quay.io/jacding/hw-event-proxy:lates
 export VERSION=latest
 export PROXY_IMG=quay.io/openshift/origin-baremetal-hardware-event-proxy:${VERSION}
 export SIDECAR_IMG=quay.io/openshift/origin-cloud-event-proxy:${VERSION}
-export CONSUMER_IMG=quay.io/redhat-cne/cloud-native-event-consumer:${VERSION}
+export CONSUMER_IMG=quay.io/redhat-cne/cloud-event-consumer:${VERSION}
 # replace the following with real Redfish credentials and BMC ip address
 export REDFISH_USERNAME=admin; export REDFISH_PASSWORD=admin; export REDFISH_HOSTADDR=127.0.0.1
 ```

--- a/e2e-tests/scripts/test.sh
+++ b/e2e-tests/scripts/test.sh
@@ -97,7 +97,7 @@ fail_test(){
     kubectl -n ${NAMESPACE} logs --tail=50 -c hw-event-proxy $hw_event_proxy_pod >> ${LOG_DIR}/last_log_$hw_event_proxy_pod.log &
     for consumer_pod in `kubectl -n ${NAMESPACE} get pods | grep consumer| cut -f1 -d" "`; do
          echo "--- consumer $consumer_pod logs ---"
-         kubectl -n ${NAMESPACE} logs --tail=50 -c cloud-native-event-consumer $consumer_pod >> ${LOG_DIR}/last_log_$consumer_pod.log &
+         kubectl -n ${NAMESPACE} logs --tail=50 -c cloud-event-consumer $consumer_pod >> ${LOG_DIR}/last_log_$consumer_pod.log &
     done
 
     echo "Check directory ${LOG_DIR} for more logs."
@@ -110,7 +110,7 @@ test_sanity() {
     # streaming logs for multiple consumers.
     echo "--- Start streaming consumer logs ---"
     consumer_pod=`kubectl -n ${NAMESPACE} get pods | grep consumer| cut -f1 -d" "`
-    kubectl -n ${NAMESPACE} logs -f --tail=1 -c cloud-native-event-consumer $consumer_pod >> ${LOG_DIR}/$consumer_pod.log &
+    kubectl -n ${NAMESPACE} logs -f --tail=1 -c cloud-event-consumer $consumer_pod >> ${LOG_DIR}/$consumer_pod.log &
     echo "$!" > ${LOG_DIR}/log-$consumer_pod.pid
 
     # start the test
@@ -145,7 +145,7 @@ test_perf() {
     # streaming logs for multiple consumers.
     echo "--- Start streaming consumer logs ---"
     for consumer_pod in `kubectl -n ${NAMESPACE} get pods | grep consumer| cut -f1 -d" "`; do
-        kubectl -n ${NAMESPACE} logs -f -c cloud-native-event-consumer $consumer_pod | grep "Latency for the event" >> ${LOG_DIR}/$consumer_pod.log &
+        kubectl -n ${NAMESPACE} logs -f -c cloud-event-consumer $consumer_pod | grep "Latency for the event" >> ${LOG_DIR}/$consumer_pod.log &
         echo "$!" > ${LOG_DIR}/log-$consumer_pod.pid
     done
 

--- a/hw-event-proxy/cmd/main.go
+++ b/hw-event-proxy/cmd/main.go
@@ -73,7 +73,7 @@ func main() {
 		nodeName = "mock"
 	}
 
-	resourceAddress = fmt.Sprintf("/cluster/node/%s/redfish/event", nodeName)
+	resourceAddress = fmt.Sprintf("/cluster/node/%s%s", nodeName, string(redfish.Systems))
 	baseURL = types.ParseURI(fmt.Sprintf("http://localhost:%d%s", apiPort, apiPath))
 
 	// check sidecar api health

--- a/manifests/amq-installer/config.yaml
+++ b/manifests/amq-installer/config.yaml
@@ -14,6 +14,7 @@ data:
     }
 
     listener {
+        # for ipv6 use host: ::
         host: 0.0.0.0
         port: 5672
         role: normal

--- a/manifests/base/consumer.yaml
+++ b/manifests/base/consumer.yaml
@@ -26,12 +26,12 @@ spec:
                       - local
       serviceAccountName: sidecar-consumer-sa
       containers:
-        - name: cloud-native-event-consumer
-          image: quay.io/redhat-cne/cloud-native-event-consumer
+        - name: cloud-event-consumer
+          image: quay.io/redhat-cne/cloud-event-consumer
           args:
-            - "--local-api-addr=127.0.0.1:9089"
+            - "--local-api-addr=localhost:9089"
             - "--api-path=/api/cloudNotifications/v1/"
-            - "--api-addr=127.0.0.1:8089"
+            - "--api-addr=localhost:8089"
           env:
             - name: NODE_NAME
               valueFrom:


### PR DESCRIPTION
Update consumer image to cloud-event-consumer.
Update resourceAddress to use default redfish resource /redfish/v1/Systems.

Signed-off-by: Jack Ding <jacding@redhat.com>