### PR TITLE
Remove python3.6 alternative in image

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -24,7 +24,8 @@ COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
 
 RUN microdnf install -y python39-pip python39-devel gcc-c++ && \
     microdnf clean all && \
-    ln -sf /usr/bin/python3.9 /usr/local/bin/python
+    ln -sf /usr/bin/python3.9 /usr/local/bin/python && \
+    alternatives --remove python3 /usr/bin/python3.6
 
 ENV PYTHON_DEPS=/usr/src/deps
 RUN mkdir -p ${PYTHON_DEPS}


### PR DESCRIPTION
Updated Dockerfile.art to remove python3.6 from the alternatives. This
falls back to the lower-priority python3.9 alternative for the python3
symbolic link, ensuring python3.9 is the runtime python.

Signed-off-by: Don Penney <dpenney@redhat.com>

/cc @jzding 