### PR TITLE
Fix e2e-test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ undeploy:update-image
 
 deploy-amq:update-image redfish-config label-node
 	$(KUSTOMIZE) build ./manifests/amq-installer | kubectl apply -f -
+	kubectl -n amq-router wait --for condition=available --timeout=60s deployment/amq-router
 	$(KUSTOMIZE) build ./manifests/ns | kubectl apply -f -
 	$(KUSTOMIZE) build ./manifests/layers/proxy-amq | kubectl apply -f -
 	$(KUSTOMIZE) build ./manifests/layers/consumer-amq | kubectl apply -f -
@@ -81,8 +82,8 @@ deploy-amq:update-image redfish-config label-node
 undeploy-amq:update-image
 	$(KUSTOMIZE) build ./manifests/layers/consumer-amq | kubectl delete -f - | true
 	$(KUSTOMIZE) build ./manifests/layers/proxy-amq | kubectl delete -f - | true
-	$(KUSTOMIZE) build ./manifests/ns | kubectl delete -f
-	$(KUSTOMIZE) build ./manifests/amq-installer | kubectl delete -f
+	$(KUSTOMIZE) build ./manifests/ns | kubectl delete -f -
+	$(KUSTOMIZE) build ./manifests/amq-installer | kubectl delete -f -
 
 deploy-perf:update-image redfish-config label-node
 	$(KUSTOMIZE) build ./manifests/ns | kubectl apply -f -
@@ -98,6 +99,7 @@ undeploy-perf:update-image
 
 deploy-perf-amq:update-image redfish-config label-node
 	$(KUSTOMIZE) build ./manifests/amq-installer | kubectl apply -f -
+	kubectl -n amq-router wait --for condition=available --timeout=60s deployment/amq-router
 	$(KUSTOMIZE) build ./manifests/ns | kubectl apply -f -
 	$(KUSTOMIZE) build ./manifests/layers/proxy-amq | kubectl apply -f -
 	$(KUSTOMIZE) build ./manifests/layers/multi-consumer-amq | kubectl apply -f -

--- a/docs/development.md
+++ b/docs/development.md
@@ -228,8 +228,9 @@ curl -X POST -i --insecure https://$(kubectl -n openshift-bare-metal-events get 
 ```
 export SIDECAR_IMG=quay.io/redhat-cne/cloud-event-proxy:release-4.10
 export CONSUMER_IMG=quay.io/redhat-cne/cloud-event-consumer:release-4.10
-make deploy-consumer-amq
 
+# assuming amqp service is running at amq-router.amq-router
+make deploy-consumer-amq
 make undeploy-consumer-amq
 ```
 

--- a/manifests/layers/multi-consumer-amq/update-transport-consumer.yaml
+++ b/manifests/layers/multi-consumer-amq/update-transport-consumer.yaml
@@ -11,8 +11,8 @@ spec:
             - name: TRANSPORT_PROTOCAL
               value: "amqp"
             - name: TRANSPORT_SERVICE
-              value: "router"
+              value: "amq-router"
             - name: TRANSPORT_NAMESPACE
-              value: "router"
+              value: "amq-router"
             - name: TRANSPORT_PORT
               value: ""

--- a/manifests/layers/proxy-amq/update-transport-proxy.yaml
+++ b/manifests/layers/proxy-amq/update-transport-proxy.yaml
@@ -11,8 +11,8 @@ spec:
             - name: TRANSPORT_PROTOCAL
               value: "amqp"
             - name: TRANSPORT_SERVICE
-              value: "router"
+              value: "amq-router"
             - name: TRANSPORT_NAMESPACE
-              value: "router"
+              value: "amq-router"
             - name: TRANSPORT_PORT
               value: ""


### PR DESCRIPTION
Fix amq deployement issue introduced by previous consumer deployment update.
Fix logging of hw-event-proxy pod when operator is deployed at the same name space.
Fix intermittent failure when hw-event-proxy is deployed before amq service is available.

Signed-off-by: Jack Ding <jackding@gmail.com>