### PR TITLE
Update sdk-go and fix Redfish Oem field

### DIFF
--- a/e2e-tests/data/IDRAC.2.8.TMP0110
+++ b/e2e-tests/data/IDRAC.2.8.TMP0110
@@ -1,0 +1,32 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#Event.Event",
+  "@odata.id": "/redfish/v1/EventService/Events/4ef0b8e8-ae3b-11ed-9ff2-c84bd67ac4d4",
+  "@odata.type": "#Event.v1_5_0.Event",
+  "Context": "root",
+  "Events": [
+    {
+      "Context": "root",
+      "EventId": "2161",
+      "EventTimestamp": "2023-02-16T15:50:29-0500",
+      "EventType": "Alert",
+      "MemberId": "298",
+      "Message": "The memory module 1 temperature is outside of range.",
+      "MessageArgs": [
+        "1"
+      ],
+      "MessageArgs@odata.count": 1,
+      "MessageId": "IDRAC.2.8.TMP0110",
+      "MessageSeverity": "Critical",
+      "Severity": "Critical"
+    }
+  ],
+  "Id": "4ef0b8e8-ae3b-11ed-9ff2-c84bd67ac4d4",
+  "Name": "Event Array",
+  "Oem": {
+    "Dell": {
+      "@odata.type": "#DellEvent.v1_0_0.DellEvent",
+      "ServerHostname": ""
+    }
+  }
+}
+

--- a/e2e-tests/data/README.md
+++ b/e2e-tests/data/README.md
@@ -5,6 +5,8 @@ The events to be tested are defined in the e2e-tests/data folder with one JSON f
 > Naming convention: MessageId-\<notes\>.json
 
 ## Temp
+- IDRAC.2.8.TMP0110
+    - This is the new verison of TMP0110 sent by Dell BMC with IDRAC firmware 6.10.00.00
 - TMP0100.json
 - TMP0100-no-msg-field.json
     - No message field. Used to test Message Parser.

--- a/hw-event-proxy/go.mod
+++ b/hw-event-proxy/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/json-iterator/go v1.1.12
-	github.com/redhat-cne/sdk-go v0.1.1-0.20221026032709-e226a93f380a
+	github.com/redhat-cne/sdk-go v0.1.1-0.20230217233027-881cc8467048
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/net v0.0.0-20210903162142-ad29c8ab022f

--- a/hw-event-proxy/go.sum
+++ b/hw-event-proxy/go.sum
@@ -77,8 +77,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/redhat-cne/sdk-go v0.1.1-0.20221026032709-e226a93f380a h1:smibMemccT15M8+CxhtCfWub2hyMkd+dYL/LmisQooI=
-github.com/redhat-cne/sdk-go v0.1.1-0.20221026032709-e226a93f380a/go.mod h1:kKOXU8uyHbpwXCKrjzH4WVLq2/RZ5pchiI2LLvmFi5E=
+github.com/redhat-cne/sdk-go v0.1.1-0.20230217233027-881cc8467048 h1:bE4X4eGRzD+ZtyEBjtCiI/PxHyDeL5ypwpRvHH1v/n0=
+github.com/redhat-cne/sdk-go v0.1.1-0.20230217233027-881cc8467048/go.mod h1:kKOXU8uyHbpwXCKrjzH4WVLq2/RZ5pchiI2LLvmFi5E=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=

--- a/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/channel/doc.go
+++ b/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/channel/doc.go
@@ -1,2 +1,2 @@
-//Package channel  provides various channel types used for event.
+// Package channel  provides various channel types used for event.
 package channel

--- a/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/channel/pipeline.go
+++ b/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/channel/pipeline.go
@@ -26,7 +26,7 @@ var (
 	channelBufferSize = 10
 )
 
-//NewStatusListenerChannel ...
+// NewStatusListenerChannel ...
 func NewStatusListenerChannel(wg *sync.WaitGroup) *ListenerChannel {
 	listener := &ListenerChannel{
 		listener: make(chan RestAPIChannel, channelBufferSize),
@@ -38,7 +38,7 @@ func NewStatusListenerChannel(wg *sync.WaitGroup) *ListenerChannel {
 	return listener
 }
 
-//NewStatusRestAPIChannel ...
+// NewStatusRestAPIChannel ...
 func NewStatusRestAPIChannel(seqID int, dataCh chan<- cloudevents.Event) RestAPIChannel {
 	return RestAPIChannel{
 		sequenceID: seqID,
@@ -46,27 +46,27 @@ func NewStatusRestAPIChannel(seqID int, dataCh chan<- cloudevents.Event) RestAPI
 	}
 }
 
-//RestAPIChannel ...
+// RestAPIChannel ...
 type RestAPIChannel struct {
 	sequenceID int
 	dataCh     chan<- cloudevents.Event
 }
 
-//ListenerChannel ...
+// ListenerChannel ...
 type ListenerChannel struct {
 	listener chan RestAPIChannel
 	store    map[int]chan<- cloudevents.Event
 	done     chan bool
 }
 
-//Done ...
+// Done ...
 func (s *ListenerChannel) Done() {
 	s.done <- true
 }
 
-//Listen ...
+// Listen ...
 // put in the map; so the you receiver will read the map and sequence id is found then
-//send to channel found in the map
+// send to channel found in the map
 func (s *ListenerChannel) Listen(wg *sync.WaitGroup) {
 	defer wg.Done()
 	defer func() {
@@ -84,9 +84,9 @@ func (s *ListenerChannel) Listen(wg *sync.WaitGroup) {
 	}
 }
 
-//SendToCaller ...
-//TODO:Clean up store on errors
-//SendToCaller ...
+// SendToCaller ...
+// TODO:Clean up store on errors
+// SendToCaller ...
 func (s *ListenerChannel) SendToCaller(sequenceID int, dataCh cloudevents.Event) {
 	if d, ok := s.store[sequenceID]; ok {
 		d <- dataCh
@@ -96,7 +96,7 @@ func (s *ListenerChannel) SendToCaller(sequenceID int, dataCh cloudevents.Event)
 	}
 }
 
-//GetChannel ...
+// GetChannel ...
 func (s *ListenerChannel) GetChannel(sequenceID int) chan<- cloudevents.Event {
 	if d, ok := s.store[sequenceID]; ok {
 		return d
@@ -104,12 +104,12 @@ func (s *ListenerChannel) GetChannel(sequenceID int) chan<- cloudevents.Event {
 	return nil
 }
 
-//SetChannel ...
+// SetChannel ...
 func (s *ListenerChannel) SetChannel(seq int, dataCh chan<- cloudevents.Event) {
 	s.store[seq] = dataCh
 }
 
-//SendToListener ...
+// SendToListener ...
 func (s *ListenerChannel) SendToListener(fromRest RestAPIChannel) {
 	s.listener <- fromRest
 }

--- a/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/channel/types.go
+++ b/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/channel/types.go
@@ -14,7 +14,7 @@
 
 package channel
 
-//Status specifies status of the event
+// Status specifies status of the event
 type Status int
 
 const (
@@ -28,12 +28,12 @@ const (
 	FAILED
 )
 
-//String represent of status enum
+// String represent of status enum
 func (s Status) String() string {
 	return [...]string{"NEW", "SUCCESS", "DELETE", "FAILED"}[s]
 }
 
-//Type ... specifies type of the event
+// Type ... specifies type of the event
 type Type int
 
 const (

--- a/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/event/event.go
+++ b/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/event/event.go
@@ -25,27 +25,29 @@ import (
 
 // Event represents the canonical representation of a Cloud Native Event.
 // Event Json  payload is as follows,
-//{
-//	"id": "5ce55d17-9234-4fee-a589-d0f10cb32b8e",
-//	"type": "event.sync.sync-status.synchronization-state-change",
-//	"source": "/cluster/node/example.com/ptp/clock_realtime",
-//	"time": "2021-02-05T17:31:00Z",
-//	"data": {
-//		"version": "v1.0",
-//		"values": [{
-//			"resource": "/sync/sync-status/sync-state",
-//			"dataType": "notification",
-//			"valueType": "enumeration",
-//			"value": "ACQUIRING-SYNC"
-//			}, {
-//			"resource": "/sync/sync-status/sync-state",
-//			"dataType": "metric",
-//			"valueType": "decimal64.3",
-//			"value": 100.3
-//			}]
-//		}
-//}
-//Event request model
+//
+//	{
+//		"id": "5ce55d17-9234-4fee-a589-d0f10cb32b8e",
+//		"type": "event.sync.sync-status.synchronization-state-change",
+//		"source": "/cluster/node/example.com/ptp/clock_realtime",
+//		"time": "2021-02-05T17:31:00Z",
+//		"data": {
+//			"version": "v1.0",
+//			"values": [{
+//				"resource": "/sync/sync-status/sync-state",
+//				"dataType": "notification",
+//				"valueType": "enumeration",
+//				"value": "ACQUIRING-SYNC"
+//				}, {
+//				"resource": "/sync/sync-status/sync-state",
+//				"dataType": "metric",
+//				"valueType": "decimal64.3",
+//				"value": 100.3
+//				}]
+//			}
+//	}
+//
+// Event request model
 type Event struct {
 	// ID of the event; must be non-empty and unique within the scope of the producer.
 	// +required

--- a/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/event/event_ce.go
+++ b/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/event/event_ce.go
@@ -23,7 +23,7 @@ import (
 	"github.com/redhat-cne/sdk-go/pkg/pubsub"
 )
 
-//NewCloudEvent create new cloud event from cloud native events and pubsub
+// NewCloudEvent create new cloud event from cloud native events and pubsub
 func (e *Event) NewCloudEvent(ps *pubsub.PubSub) (*cloudevent.Event, error) {
 	ce := cloudevent.NewEvent(cloudevent.VersionV03)
 	ce.SetTime(e.GetTime())

--- a/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/event/event_data.go
+++ b/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/event/event_data.go
@@ -43,32 +43,33 @@ const (
 
 // Data ... cloud native events data
 // Data Json payload is as follows,
-//{
-//	"version": "v1.0",
-//	"values": [{
-//		"resource": "/sync/sync-status/sync-state",
-//		"dataType": "notification",
-//		"valueType": "enumeration",
-//		"value": "ACQUIRING-SYNC"
-//		}, {
-//		"resource": "/sync/sync-status/sync-state",
-//		"dataType": "metric",
-//		"valueType": "decimal64.3",
-//		"value": 100.3
-//		}, {
-//		"resource": "/redfish/v1/Systems",
-//		"dataType": "notification",
-//		"valueType": "redfish-event",
-//		"value": {
-// 		    "@odata.context": "/redfish/v1/$metadata#Event.Event",
-// 		    "@odata.type": "#Event.v1_3_0.Event",
-// 		    "Context": "any string is valid",
-// 		    "Events": [{"EventId": "2162", "MemberId": "615703", "MessageId": "TMP0100"}],
-// 		    "Id": "5e004f5a-e3d1-11eb-ae9c-3448edf18a38",
-// 		    "Name": "Event Array"
-//		}
-//	}]
-//}
+//
+//	{
+//		"version": "v1.0",
+//		"values": [{
+//			"resource": "/sync/sync-status/sync-state",
+//			"dataType": "notification",
+//			"valueType": "enumeration",
+//			"value": "ACQUIRING-SYNC"
+//			}, {
+//			"resource": "/sync/sync-status/sync-state",
+//			"dataType": "metric",
+//			"valueType": "decimal64.3",
+//			"value": 100.3
+//			}, {
+//			"resource": "/redfish/v1/Systems",
+//			"dataType": "notification",
+//			"valueType": "redfish-event",
+//			"value": {
+//			    "@odata.context": "/redfish/v1/$metadata#Event.Event",
+//			    "@odata.type": "#Event.v1_3_0.Event",
+//			    "Context": "any string is valid",
+//			    "Events": [{"EventId": "2162", "MemberId": "615703", "MessageId": "TMP0100"}],
+//			    "Id": "5e004f5a-e3d1-11eb-ae9c-3448edf18a38",
+//			    "Name": "Event Array"
+//			}
+//		}]
+//	}
 type Data struct {
 	Version string      `json:"version" example:"v1"`
 	Values  []DataValue `json:"values"`
@@ -76,12 +77,13 @@ type Data struct {
 
 // DataValue ...
 // DataValue Json payload is as follows,
-//{
-//	"resource": "/cluster/node/ptp",
-//	"dataType": "notification",
-//	"valueType": "enumeration",
-//	"value": "ACQUIRING-SYNC"
-//}
+//
+//	{
+//		"resource": "/cluster/node/ptp",
+//		"dataType": "notification",
+//		"valueType": "enumeration",
+//		"value": "ACQUIRING-SYNC"
+//	}
 type DataValue struct {
 	Resource  string      `json:"resource" example:"/cluster/node/clock"`
 	DataType  DataType    `json:"dataType" example:"metric"`

--- a/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/event/event_writer.go
+++ b/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/event/event_writer.go
@@ -72,7 +72,7 @@ func (e *Event) SetDataContentType(ct string) {
 	}
 }
 
-//SetData ...
+// SetData ...
 func (e *Event) SetData(data Data) {
 	nData := Data{
 		Version: data.Version,

--- a/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/event/redfish/event_marshal.go
+++ b/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/event/redfish/event_marshal.go
@@ -59,6 +59,7 @@ func WriteJSONEvent(in *Event, writer io.Writer, stream *jsoniter.Stream) error 
 			if err != nil {
 				return fmt.Errorf("error writing Oem: %w", err)
 			}
+			stream.WriteMore()
 		}
 		if data.OdataType != "" {
 			stream.WriteObjectField("@odata.type")

--- a/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/pubsub/pubsub.go
+++ b/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/pubsub/pubsub.go
@@ -22,12 +22,14 @@ import (
 
 // PubSub represents the canonical representation of a Cloud Native Event Publisher and Sender .
 // PubSub Json request payload is as follows,
-// {
-//  "id": "789be75d-7ac3-472e-bbbc-6d62878aad4a",
-//  "endpointUri": "http://localhost:9090/ack/event",
-//  "uriLocation":  "http://localhost:8080/api/ocloudNotifications/v1/publishers/{publisherid}",
-//  "resource":  "/east-edge-10/vdu3/o-ran-sync/sync-group/sync-status/sync-state"
-// }
+//
+//	{
+//	 "id": "789be75d-7ac3-472e-bbbc-6d62878aad4a",
+//	 "endpointUri": "http://localhost:9090/ack/event",
+//	 "uriLocation":  "http://localhost:8080/api/ocloudNotifications/v1/publishers/{publisherid}",
+//	 "resource":  "/east-edge-10/vdu3/o-ran-sync/sync-group/sync-status/sync-state"
+//	}
+//
 // PubSub request model
 type PubSub struct {
 	// ID of the pub/sub; is updated on successful creation of publisher/subscription.

--- a/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/types/value.go
+++ b/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/types/value.go
@@ -97,7 +97,8 @@ func Format(v interface{}) (string, error) {
 }
 
 // Validate v is a valid CNE attribute value, convert it to one of:
-//     bool, int32, string, []byte, types.URI, types.URIRef, types.Timestamp
+//
+//	bool, int32, string, []byte, types.URI, types.URIRef, types.Timestamp
 func Validate(v interface{}) (interface{}, error) {
 	switch v := v.(type) {
 	case bool, int32, string, []byte:
@@ -155,7 +156,9 @@ func Validate(v interface{}) (interface{}, error) {
 }
 
 // Clone v clones a CNE attribute value, which is one of the valid types:
-//     bool, int32, string, []byte, types.URI, types.URIRef, types.Timestamp
+//
+//	bool, int32, string, []byte, types.URI, types.URIRef, types.Timestamp
+//
 // Returns the same type
 // Panics if the type is not valid
 func Clone(v interface{}) interface{} {

--- a/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/util/wait/wait.go
+++ b/hw-event-proxy/vendor/github.com/redhat-cne/sdk-go/pkg/util/wait/wait.go
@@ -28,10 +28,12 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-//ForeverTestTimeout ... For any test of the style:
-//   ...
-//   <- time.After(timeout):
-//      t.Errorf("Timed out")
+// ForeverTestTimeout ... For any test of the style:
+//
+//	...
+//	<- time.After(timeout):
+//	   t.Errorf("Timed out")
+//
 // The value for timeout should effectively be "forever." Obviously we don't want our tests to truly lock up forever, but 30s
 // is long enough that it is effectively forever for the things that can slow down a run on a heavily contended machine
 // (GC, seeks, etc), but not so long as to make a developer ctrl-c a test run if they do happen to break that test.
@@ -527,7 +529,7 @@ type WaitFunc func(done <-chan struct{}) <-chan struct{}
 
 // WaitFor continually checks 'fn' as driven by 'wait'.
 //
-// WaitFor gets a channel from 'wait()'', and then invokes 'fn' once for every value
+// WaitFor gets a channel from 'wait()”, and then invokes 'fn' once for every value
 // placed on the channel and once more when the channel is closed. If the channel is closed
 // and 'fn' returns false without error, WaitFor returns ErrWaitTimeout.
 //

--- a/hw-event-proxy/vendor/modules.txt
+++ b/hw-event-proxy/vendor/modules.txt
@@ -42,7 +42,7 @@ github.com/modern-go/reflect2
 # github.com/pmezard/go-difflib v1.0.0
 ## explicit
 github.com/pmezard/go-difflib/difflib
-# github.com/redhat-cne/sdk-go v0.1.1-0.20221026032709-e226a93f380a
+# github.com/redhat-cne/sdk-go v0.1.1-0.20230217233027-881cc8467048
 ## explicit; go 1.17
 github.com/redhat-cne/sdk-go/pkg/channel
 github.com/redhat-cne/sdk-go/pkg/event


### PR DESCRIPTION
- Fix Redfish Event parsing for Oem field
- add `IDRAC.2.8.TMP0110` event to e2e test. This is the new verison of TMP0110 sent by Dell BMC with IDRAC firmware 6.10.00.00, which added a  `Oem` field.
