### PR TITLE
Added a comment to manually propagate Dockerfile changes to the midstream repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# Changes to this file are not auto-propagated to the downstream build automation. We need to make the changes manually in the midstream repo located here:
+# https://gitlab.cee.redhat.com/cpaas-midstream/telco-5g-ran/baremetal-hardware-event-proxy/-/blob/rhaos-4.13-rhel-8/distgit/containers/baremetal-hardware-event-proxy/Dockerfile.in
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS go-builder
 ENV GO111MODULE=off
 ENV CGO_ENABLED=1


### PR DESCRIPTION
Add a reminder that Dockerfile changes need to be manually propagated to the midstream repository